### PR TITLE
Android TV launcher icon fix

### DIFF
--- a/Houseclub/src/main/AndroidManifest.xml
+++ b/Houseclub/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
+	<uses-feature android:name="android.software.leanback" android:required="false" />
+	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+
 	<application
 		android:allowBackup="true"
 		android:label="@string/app_name"
@@ -18,11 +21,13 @@
 		android:name=".App"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
-		android:usesCleartextTraffic="true">
+		android:usesCleartextTraffic="true"
+		android:banner="@mipmap/ic_launcher">
 		<activity android:name=".MainActivity" android:configChanges="screenSize|orientation" android:launchMode="singleTask">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
 				<category android:name="android.intent.category.LAUNCHER"/>
+				<category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
 			</intent-filter>
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
Without that lines, you can't launch this app on Android TV, because it's not showing in launcher. Now it looks like this:
![device-2021-02-20-173653](https://user-images.githubusercontent.com/2042119/108599478-60bfa280-73a2-11eb-92cf-52edb77c14ae.png)
